### PR TITLE
URL Cleanup

### DIFF
--- a/10-no-cowboy-dependency.patch
+++ b/10-no-cowboy-dependency.patch
@@ -45,7 +45,7 @@ index 2af0fd8..0000000
 -%% SOFTWARE.
 -%%---------------------------------------------------------------------------
 -%%
--%% @reference the <a href="http://github.com/extend/cowboy/">Cowboy github page</a>
+-%% @reference the <a href="https://github.com/extend/cowboy/">Cowboy github page</a>
 -%%
 -%% @doc Support for serving JSON-RPC via Cowboy.
 -%%


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://github.com/extend/cowboy/ with 1 occurrences migrated to:  
  https://github.com/extend/cowboy/ ([https](https://github.com/extend/cowboy/) result 301).